### PR TITLE
Add center dashed line

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -450,7 +450,7 @@ dependencies = [
  "bevy_app",
  "bevy_utils",
  "console_error_panic_hook",
- "tracing-subscriber",
+ "tracing-subscriber 0.2.25",
  "tracing-wasm",
 ]
 
@@ -1912,9 +1912,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.106"
+version = "0.2.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a60553f9a9e039a333b4e9b20573b9e9b9c0bb3a11e201ccc48ef4283456d673"
+checksum = "fbe5e23404da5b4f555ef85ebed98fb4083e55a00c317800bc2a50ede9f3d219"
 
 [[package]]
 name = "libloading"
@@ -2791,9 +2791,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.68"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f690853975602e1bfe1ccbf50504d67174e3bcf340f23b5ea9992e0587a52d8"
+checksum = "e466864e431129c7e0d3476b92f20458e5879919a0596c6472738d9fa2d342f8"
 dependencies = [
  "itoa",
  "ryu",
@@ -3158,13 +3158,24 @@ dependencies = [
 ]
 
 [[package]]
-name = "tracing-wasm"
-version = "0.2.0"
+name = "tracing-subscriber"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ae741706df70547fca8715f74a8569677666e7be3454313af70f6e158034485"
+checksum = "80a4ddde70311d8da398062ecf6fc2c309337de6b0f77d6c27aff8d53f6fca52"
+dependencies = [
+ "sharded-slab",
+ "thread_local",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-wasm"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4575c663a174420fa2d78f4108ff68f65bf2fbb7dd89f33749b6e826b3626e07"
 dependencies = [
  "tracing",
- "tracing-subscriber",
+ "tracing-subscriber 0.3.1",
  "wasm-bindgen",
 ]
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,23 @@
-use bevy::prelude::*;
-use bevy::render::pass::ClearColor;
+use bevy::{core::FixedTimestep, prelude::*, render::pass::ClearColor};
+
+fn main() {
+    App::build()
+        // Clear Color is the background color
+        .insert_resource(ClearColor(Color::rgb(0.0, 0.0, 0.0)))
+        .insert_resource(WindowDescriptor {
+            title: "Bevy Pong".to_string(),
+            width: 1000.0,
+            height: 800.0,
+            resizable: false,
+            vsync: true,
+            ..Default::default()
+        })
+        .add_plugins(DefaultPlugins)
+        .add_startup_system(startup_system.system())
+        .add_system_set(SystemSet::new().with_run_criteria(FixedTimestep::step(TIME_STEP as f64)))
+        .add_system(render_system.system())
+        .run();
+}
 
 /*
  * Entities
@@ -32,15 +50,6 @@ struct Vector {
 
 struct Ball;
 
-const LEFT_PLAYER_ORIGIN: Position = Position { x: -25.0, y: 0.0 };
-const RIGHT_PLAYER_ORIGIN: Position = Position { x: 25.0, y: 0.0 };
-const BALL_ORIGIN: Position = Position { x: 0.0, y: 0.0 };
-const PADDLE_SIZE: [f32; 2] = [6.0, 36.0];
-const DASH_WIDTH: f32 = 1.0;
-const DASH_HEIGHT: f32 = 8.0;
-const DASH_SIZE: [f32; 2] = [DASH_WIDTH, DASH_HEIGHT];
-const DASH_PADDING: f32 = 20.0;
-
 // The origin (0,0) of bevy's coordinate system is in the center of the screen
 fn startup_system(
     mut commands: Commands,
@@ -48,8 +57,6 @@ fn startup_system(
     window: Res<WindowDescriptor>,
 ) {
     commands.spawn_bundle(OrthographicCameraBundle::new_2d());
-    commands.spawn_bundle(UiCameraBundle::default());
-    // Left Player
     commands
         .spawn_bundle(SpriteBundle {
             material: materials.add(Color::rgb(1.0, 1.0, 1.0).into()),
@@ -110,21 +117,12 @@ fn render_system(mut query: Query<(&Position, &mut Transform)>, window: Res<Wind
     }
 }
 
-// 1. query for paddles, get components, mutate position
-fn main() {
-    App::build()
-        // Clear Color is the background color
-        .insert_resource(ClearColor(Color::rgb(0.0, 0.0, 0.0)))
-        .insert_resource(WindowDescriptor {
-            title: "Bevy Pong".to_string(),
-            width: 1000.0,
-            height: 800.0,
-            resizable: false,
-            vsync: true,
-            ..Default::default()
-        })
-        .add_plugins(DefaultPlugins)
-        .add_startup_system(startup_system.system())
-        .add_system(render_system.system())
-        .run();
-}
+const TIME_STEP: f32 = 1.0 / 60.0;
+const LEFT_PLAYER_ORIGIN: Position = Position { x: -25.0, y: 0.0 };
+const RIGHT_PLAYER_ORIGIN: Position = Position { x: 25.0, y: 0.0 };
+const BALL_ORIGIN: Position = Position { x: 0.0, y: 0.0 };
+const PADDLE_SIZE: [f32; 2] = [6.0, 36.0];
+const DASH_WIDTH: f32 = 1.0;
+const DASH_HEIGHT: f32 = 8.0;
+const DASH_SIZE: [f32; 2] = [DASH_WIDTH, DASH_HEIGHT];
+const DASH_PADDING: f32 = 20.0;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,22 +1,30 @@
 use bevy::prelude::*;
 use bevy::render::pass::ClearColor;
 
-// Entities
+/*
+ * Entities
+ */
+
 enum PlayerType {
-    TopPlayer,
-    BottomPlayer,
+    LeftPlayer,
+    RightPlayer,
 }
 struct Paddle {
     player_type: PlayerType,
 }
 
-// Components
+/*
+ * Components
+ */
 
+// Positions are percentage based
 struct Position {
     x: f32,
     y: f32,
 }
 
+// Vectors components are described as scalars between [0,1]
+// with two decimal places of precision
 struct Vector {
     x: f32,
     y: f32,
@@ -24,30 +32,46 @@ struct Vector {
 
 struct Ball;
 
-fn initialize_player(mut commands: Commands, mut materials: ResMut<Assets<ColorMaterial>>) {
-    println!("initialize_player called");
+const LEFT_PLAYER_ORIGIN: Position = Position { x: -25.0, y: 0.0 };
+const RIGHT_PLAYER_ORIGIN: Position = Position { x: 25.0, y: 0.0 };
+const BALL_ORIGIN: Position = Position { x: 0.0, y: 0.0 };
+const PADDLE_SIZE: [f32; 2] = [6.0, 36.0];
+const DASH_WIDTH: f32 = 1.0;
+const DASH_HEIGHT: f32 = 8.0;
+const DASH_SIZE: [f32; 2] = [DASH_WIDTH, DASH_HEIGHT];
+const DASH_PADDING: f32 = 20.0;
+
+// The origin (0,0) of bevy's coordinate system is in the center of the screen
+fn startup_system(
+    mut commands: Commands,
+    mut materials: ResMut<Assets<ColorMaterial>>,
+    window: Res<WindowDescriptor>,
+) {
     commands.spawn_bundle(OrthographicCameraBundle::new_2d());
     commands.spawn_bundle(UiCameraBundle::default());
+    // Left Player
     commands
         .spawn_bundle(SpriteBundle {
             material: materials.add(Color::rgb(1.0, 1.0, 1.0).into()),
-            sprite: Sprite::new(Vec2::new(20.0, 100.0)),
+            sprite: Sprite::new(Vec2::from(PADDLE_SIZE)),
             ..Default::default()
         })
         .insert(Paddle {
-            player_type: PlayerType::TopPlayer,
+            player_type: PlayerType::LeftPlayer,
         })
-        .insert(Position { x: 20.0, y: 50.0 });
+        .insert(LEFT_PLAYER_ORIGIN);
+    // Right Player
     commands
         .spawn_bundle(SpriteBundle {
             material: materials.add(Color::rgb(1.0, 1.0, 1.0).into()),
-            sprite: Sprite::new(Vec2::new(20.0, 100.0)),
+            sprite: Sprite::new(Vec2::from(PADDLE_SIZE)),
             ..Default::default()
         })
         .insert(Paddle {
-            player_type: PlayerType::BottomPlayer,
+            player_type: PlayerType::RightPlayer,
         })
-        .insert(Position { x: 50.0, y: 50.0 });
+        .insert(RIGHT_PLAYER_ORIGIN);
+    // Ball
     commands
         .spawn_bundle(SpriteBundle {
             material: materials.add(Color::rgb(1.0, 1.0, 1.0).into()),
@@ -55,32 +79,52 @@ fn initialize_player(mut commands: Commands, mut materials: ResMut<Assets<ColorM
             ..Default::default()
         })
         .insert(Ball)
-        .insert(Position { x: 30.0, y: 50.0 });
+        .insert(BALL_ORIGIN);
+
+    // Compute how many dashes can fit evenly vertically in the window with DASH_PADDING inbetween
+    let window_top = (window.height / 2.0).abs();
+    let dash_material = materials.add(Color::rgb(1.0, 1.0, 1.0).into());
+    let dash_sprite = Sprite::new(Vec2::from(DASH_SIZE));
+    let dash_count = ((window.height) / (DASH_HEIGHT + DASH_PADDING)).floor() as u16;
+    let mut dashes = vec![];
+    for i in 0..=dash_count {
+        // let padding = if i == 0 { 0.0 } else { DASH_PADDING };
+        let y = window_top - (i as f32 * (DASH_PADDING + DASH_HEIGHT));
+        dashes.push(SpriteBundle {
+            material: dash_material.clone(),
+            sprite: dash_sprite.clone(),
+            transform: Transform::from_translation(Vec3::new(0.0, y, 0.0)),
+            ..Default::default()
+        });
+    }
+
+    commands.spawn_batch(dashes);
 }
 
 // Convert relative position to absolute
 fn render_system(mut query: Query<(&Position, &mut Transform)>, window: Res<WindowDescriptor>) {
     for (position, mut transform) in query.iter_mut() {
         let translation = &mut transform.translation;
-        translation.x = (position.x - 50.0) / 100.0 * window.width;
-        translation.y = (position.y - 50.0) / 100.0 * window.height;
+        translation.x = position.x / 100.0 * window.width;
+        translation.y = position.y / 100.0 * window.height;
     }
 }
 
 // 1. query for paddles, get components, mutate position
 fn main() {
     App::build()
+        // Clear Color is the background color
         .insert_resource(ClearColor(Color::rgb(0.0, 0.0, 0.0)))
         .insert_resource(WindowDescriptor {
             title: "Bevy Pong".to_string(),
             width: 1000.0,
-            height: 1000.0,
+            height: 800.0,
             resizable: false,
             vsync: true,
             ..Default::default()
         })
         .add_plugins(DefaultPlugins)
-        .add_startup_system(initialize_player.system())
+        .add_startup_system(startup_system.system())
         .add_system(render_system.system())
         .run();
 }


### PR DESCRIPTION
Fixes positioning of sprites to comply with bevy's origin being in
the center of the window. This is the default behavior and it seems
easiest to cooperate with bevy.

Adds a dashed line down the center of the window. Dashed line is just a
batch of bevy SpriteBundles. As best as I can tell there is no way to
render a dashed-line using the existing bevy APIs. Positioning of the
dashed line is adaptive based on the window but uses pixels rather than
relative distances.

There is a slight misalignment I was not able to solve appropriately.
The correct implementation involves:
1. Defining a top/bottom "gutter" (space where no dashed line is
   rendered)
2. Rendering a dashed line on top and one on bottom
3. Computing the remaining space between lowest point of the top dash
   and the highest point of the bottom dash; then figuring out how many
   dashes can fit in between with equal spacing.

This layout is quite similar to `flex` in the browser. Since Rust was
written for Servo in Mozilla it only figures that we find ourselves at
this point again. Déjà vu.