### PR TITLE
Wall collisions and round system

### DIFF
--- a/src/constants.rs
+++ b/src/constants.rs
@@ -1,8 +1,3 @@
-use crate::Position;
-
-pub const LEFT_PLAYER_ORIGIN: Position = Position { x: -42.5, y: 0.0 };
-pub const RIGHT_PLAYER_ORIGIN: Position = Position { x: 42.5, y: 0.0 };
-pub const BALL_ORIGIN: Position = Position { x: 0.0, y: 0.0 };
 pub const BALL_SIZE: [f32; 2] = [5.0, 5.0];
 pub const PADDLE_HEIGHT: f32 = 36.0;
 pub const PADDLE_SIZE: [f32; 2] = [6.0, PADDLE_HEIGHT];
@@ -10,3 +5,4 @@ pub const DASH_WIDTH: f32 = 1.0;
 pub const DASH_HEIGHT: f32 = 8.0;
 pub const DASH_SIZE: [f32; 2] = [DASH_WIDTH, DASH_HEIGHT];
 pub const DASH_PADDING: f32 = 20.0;
+pub const PADDLE_VELOCITY: f32 = 10.0;

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -1,0 +1,12 @@
+use crate::Position;
+
+pub const LEFT_PLAYER_ORIGIN: Position = Position { x: -42.5, y: 0.0 };
+pub const RIGHT_PLAYER_ORIGIN: Position = Position { x: 42.5, y: 0.0 };
+pub const BALL_ORIGIN: Position = Position { x: 0.0, y: 0.0 };
+pub const BALL_SIZE: [f32; 2] = [5.0, 5.0];
+pub const PADDLE_HEIGHT: f32 = 36.0;
+pub const PADDLE_SIZE: [f32; 2] = [6.0, PADDLE_HEIGHT];
+pub const DASH_WIDTH: f32 = 1.0;
+pub const DASH_HEIGHT: f32 = 8.0;
+pub const DASH_SIZE: [f32; 2] = [DASH_WIDTH, DASH_HEIGHT];
+pub const DASH_PADDING: f32 = 20.0;

--- a/src/main.rs
+++ b/src/main.rs
@@ -148,34 +148,57 @@ fn startup_system(
 
     // Invisible walls for collision detection
     let wall_material = materials.add(Color::rgb(1.0, 1.0, 1.0).into());
-    let wall_thickess = BALL_SIZE[0];
-    // Left Side -> Top Wall
+    let wall_thickness = BALL_SIZE[0];
+    // Left Side -> Top, Left, Bottom
     commands
         .spawn_bundle(SpriteBundle {
             material: wall_material.clone(),
-            sprite: Sprite::new(Vec2::new(window.width / 2.0, wall_thickess)),
+            sprite: Sprite::new(Vec2::new(window.width / 2.0, wall_thickness)),
             transform: Transform::from_xyz(-window.width / 4.0, (window.height / 2.0) - 1.0, 0.0),
             ..Default::default()
         })
         .insert(WallSide::Left);
-    // Left Side -> Left Wall
     commands
         .spawn_bundle(SpriteBundle {
             material: wall_material.clone(),
-            sprite: Sprite::new(Vec2::new(wall_thickess, window.height)),
+            sprite: Sprite::new(Vec2::new(wall_thickness, window.height)),
             transform: Transform::from_xyz((-window.width / 2.0) + 1.0, 0.0, 0.0),
             ..Default::default()
         })
         .insert(WallSide::Left);
-    // Left Side -> Bottom Wall
     commands
         .spawn_bundle(SpriteBundle {
-            material: wall_material,
-            sprite: Sprite::new(Vec2::new(window.width / 2.0, wall_thickess)),
+            material: wall_material.clone(),
+            sprite: Sprite::new(Vec2::new(window.width / 2.0, wall_thickness)),
             transform: Transform::from_xyz(-window.width / 4.0, -(window.height / 2.0) + 1.0, 0.0),
             ..Default::default()
         })
         .insert(WallSide::Left);
+    // Right Side -> Top, Right, Bottom
+    commands
+        .spawn_bundle(SpriteBundle {
+            material: wall_material.clone(),
+            sprite: Sprite::new(Vec2::new(window.width / 2.0, wall_thickness)),
+            transform: Transform::from_xyz(window.width / 4.0, (window.height / 2.0) - 1.0, 0.0),
+            ..Default::default()
+        })
+        .insert(WallSide::Right);
+    commands
+        .spawn_bundle(SpriteBundle {
+            material: wall_material.clone(),
+            sprite: Sprite::new(Vec2::new(wall_thickness, window.height)),
+            transform: Transform::from_xyz((window.width / 2.0) - 1.0, 0.0, 0.0),
+            ..Default::default()
+        })
+        .insert(WallSide::Right);
+    commands
+        .spawn_bundle(SpriteBundle {
+            material: wall_material,
+            sprite: Sprite::new(Vec2::new(window.width / 2.0, wall_thickness)),
+            transform: Transform::from_xyz(window.width / 4.0, -(window.height / 2.0) + 1.0, 0.0),
+            ..Default::default()
+        })
+        .insert(WallSide::Right);
 
     // Dashes
     let window_top = (window.height / 2.0).abs();

--- a/src/main.rs
+++ b/src/main.rs
@@ -37,13 +37,6 @@ pub struct Player {
     player_type: PlayerType,
 }
 
-// Positions are percentage based
-#[derive(Clone)]
-pub struct Position {
-    x: f32,
-    y: f32,
-}
-
 pub struct Velocity(Vec2);
 pub struct Ball;
 pub struct LostRound;
@@ -85,7 +78,7 @@ fn main() {
                 .with_system(collision_system.system().label("collision"))
                 .with_system(velocity_system.system().after("collision")),
         )
-        .add_system(render_system.system().after("physics"))
+        // .add_system(render_system.system().after("physics"))
         .run();
 }
 
@@ -104,13 +97,13 @@ fn startup_system(
         .spawn_bundle(SpriteBundle {
             material: materials.add(Color::rgb(1.0, 1.0, 1.0).into()),
             sprite: Sprite::new(Vec2::from(PADDLE_SIZE)),
+            transform: Transform::from_xyz(0.425 * -window.width, 0.0, 0.0),
             ..Default::default()
         })
         .insert(Player {
             player_type: PlayerType::Left,
         })
         .insert(Size::new(PADDLE_SIZE[0], PADDLE_SIZE[1]))
-        .insert(LEFT_PLAYER_ORIGIN)
         .insert(Collidable::Reflect);
 
     // Right Player
@@ -118,13 +111,13 @@ fn startup_system(
         .spawn_bundle(SpriteBundle {
             material: materials.add(Color::rgb(1.0, 1.0, 1.0).into()),
             sprite: Sprite::new(Vec2::from(PADDLE_SIZE)),
+            transform: Transform::from_xyz(0.425 * window.width, 0.0, 0.0),
             ..Default::default()
         })
         .insert(Player {
             player_type: PlayerType::Right,
         })
         .insert(Size::new(PADDLE_SIZE[0], PADDLE_SIZE[1]))
-        .insert(RIGHT_PLAYER_ORIGIN)
         .insert(Collidable::Reflect);
 
     // Ball
@@ -132,12 +125,12 @@ fn startup_system(
         .spawn_bundle(SpriteBundle {
             material: materials.add(Color::rgb(1.0, 1.0, 1.0).into()),
             sprite: Sprite::new(Vec2::from(BALL_SIZE)),
+            transform: Transform::from_xyz(0.0, 0.0, 0.0),
             ..Default::default()
         })
         .insert(Ball)
-        .insert(BALL_ORIGIN)
         .insert(Size::new(BALL_SIZE[0], BALL_SIZE[1]))
-        .insert(Velocity(Vec2::new(0.65, 0.0)));
+        .insert(Velocity(Vec2::new(5.0, 0.0)));
 
     // Invisible walls for collision detection
     let wall_material = materials.add(Color::rgb(1.0, 1.0, 1.0).into());
@@ -198,11 +191,11 @@ fn startup_system(
     commands.spawn_batch(dashes);
 }
 
-// Convert relative position to absolute
-fn render_system(mut query: Query<(&Position, &mut Transform)>, window: Res<WindowDescriptor>) {
-    for (position, mut transform) in query.iter_mut() {
-        let translation = &mut transform.translation;
-        translation.x = position.x / 100.0 * window.width;
-        translation.y = position.y / 100.0 * window.height;
-    }
-}
+// // Convert relative position to absolute
+// fn render_system(mut query: Query<(&Position, &mut Transform)>, window: Res<WindowDescriptor>) {
+//     for (position, mut transform) in query.iter_mut() {
+//         let translation = &mut transform.translation;
+//         translation.x = position.x / 100.0 * window.width;
+//         translation.y = position.y / 100.0 * window.height;
+//     }
+// }

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,7 +2,10 @@ mod constants;
 mod systems;
 
 use crate::constants::*;
-use crate::systems::{collision::collision_system, round::round_system, velocity::velocity_system};
+use crate::systems::{
+    collision::collision_system, input::keyboard_input_system, round::round_system,
+    velocity::velocity_system,
+};
 use bevy::{prelude::*, render::pass::ClearColor};
 
 pub enum PrevWinner {
@@ -193,34 +196,6 @@ fn startup_system(
     }
 
     commands.spawn_batch(dashes);
-}
-
-// Controls
-// ----------------------------------
-// Player 1 -> UP -> Up Arrow Key
-// Player 1 -> DOWN -> Down Arrow Key
-// Player 2 -> UP -> 'W' Key
-// Player 2 -> DOWN -> 'S' Key
-#[allow(clippy::type_complexity)]
-fn keyboard_input_system(mut players: Query<(&mut Position, &Player)>, key: Res<Input<KeyCode>>) {
-    for (mut position, player) in players.iter_mut() {
-        match player.player_type {
-            PlayerType::Left => {
-                if key.pressed(KeyCode::W) {
-                    position.y += 1.0
-                } else if key.pressed(KeyCode::S) {
-                    position.y -= 1.0
-                }
-            }
-            PlayerType::Right => {
-                if key.pressed(KeyCode::Up) {
-                    position.y += 1.0
-                } else if key.pressed(KeyCode::Down) {
-                    position.y -= 1.0
-                }
-            }
-        }
-    }
 }
 
 // Convert relative position to absolute

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,57 @@
+mod constants;
 mod systems;
 
+use crate::constants::*;
 use crate::systems::{collision::collision_system, round::round_system, velocity::velocity_system};
 use bevy::{prelude::*, render::pass::ClearColor};
+
+pub enum PrevWinner {
+    None,
+    Player(PlayerType),
+}
+pub struct Game {
+    left_score: usize,
+    right_score: usize,
+    prev_winner: PrevWinner,
+}
+impl Default for Game {
+    fn default() -> Self {
+        Self {
+            left_score: 0,
+            right_score: 0,
+            prev_winner: PrevWinner::None,
+        }
+    }
+}
+// Player Type
+#[derive(Debug)]
+pub enum PlayerType {
+    Left,
+    Right,
+}
+#[derive(Debug)]
+pub struct Player {
+    player_type: PlayerType,
+}
+
+// Positions are percentage based
+#[derive(Clone)]
+pub struct Position {
+    x: f32,
+    y: f32,
+}
+
+pub struct Velocity(Vec2);
+pub struct Ball;
+pub struct LostRound;
+pub struct Wall {
+    side: WallSide,
+}
+#[derive(Debug)]
+pub enum WallSide {
+    Left,
+    Right,
+}
 
 fn main() {
     App::build()
@@ -33,70 +83,6 @@ fn main() {
         .add_system(render_system.system().after("physics"))
         .run();
 }
-
-/*
- * Components
- */
-
-// Player Type
-#[derive(Debug)]
-pub enum PlayerType {
-    Left,
-    Right,
-}
-#[derive(Debug)]
-pub struct Player {
-    player_type: PlayerType,
-}
-
-// Positions are percentage based
-#[derive(Clone)]
-pub struct Position {
-    x: f32,
-    y: f32,
-}
-
-pub struct Velocity(Vec2);
-pub struct Ball;
-pub struct LostRound;
-pub struct Wall {
-    side: WallSide,
-}
-#[derive(Debug)]
-pub enum WallSide {
-    Left,
-    Right,
-}
-
-pub enum PrevWinner {
-    None,
-    Player(PlayerType),
-}
-pub struct Game {
-    left_score: usize,
-    right_score: usize,
-    prev_winner: PrevWinner,
-}
-impl Default for Game {
-    fn default() -> Self {
-        Self {
-            left_score: 0,
-            right_score: 0,
-            prev_winner: PrevWinner::None,
-        }
-    }
-}
-
-pub const LEFT_PLAYER_ORIGIN: Position = Position { x: -42.5, y: 0.0 };
-pub const RIGHT_PLAYER_ORIGIN: Position = Position { x: 42.5, y: 0.0 };
-pub const BALL_ORIGIN: Position = Position { x: 0.0, y: 0.0 };
-const BALL_SIZE: [f32; 2] = [5.0, 5.0];
-const PADDLE_HEIGHT: f32 = 36.0;
-const PADDLE_SIZE: [f32; 2] = [6.0, PADDLE_HEIGHT];
-const DASH_WIDTH: f32 = 1.0;
-const DASH_HEIGHT: f32 = 8.0;
-const DASH_SIZE: [f32; 2] = [DASH_WIDTH, DASH_HEIGHT];
-const DASH_PADDING: f32 = 20.0;
 
 // The origin (0,0) of bevy's coordinate system is in the center of the screen
 fn startup_system(

--- a/src/main.rs
+++ b/src/main.rs
@@ -44,8 +44,10 @@ pub struct Position {
 pub struct Velocity(Vec2);
 pub struct Ball;
 pub struct LostRound;
-pub struct Wall {
-    side: WallSide,
+
+pub enum Collidable {
+    Reflect, // Something that is collidable but reflects the ball
+    End,     // Something that is collidable but ends the balls movement
 }
 #[derive(Debug)]
 pub enum WallSide {
@@ -105,7 +107,8 @@ fn startup_system(
             player_type: PlayerType::Left,
         })
         .insert(Size::new(PADDLE_SIZE[0], PADDLE_SIZE[1]))
-        .insert(LEFT_PLAYER_ORIGIN);
+        .insert(LEFT_PLAYER_ORIGIN)
+        .insert(Collidable::Reflect);
 
     // Right Player
     commands
@@ -118,7 +121,8 @@ fn startup_system(
             player_type: PlayerType::Right,
         })
         .insert(Size::new(PADDLE_SIZE[0], PADDLE_SIZE[1]))
-        .insert(RIGHT_PLAYER_ORIGIN);
+        .insert(RIGHT_PLAYER_ORIGIN)
+        .insert(Collidable::Reflect);
 
     // Ball
     commands
@@ -135,56 +139,42 @@ fn startup_system(
     // Invisible walls for collision detection
     let wall_material = materials.add(Color::rgb(1.0, 1.0, 1.0).into());
     let wall_thickness = BALL_SIZE[0];
-    // Left Side -> Top, Left, Bottom
-    commands
-        .spawn_bundle(SpriteBundle {
-            material: wall_material.clone(),
-            sprite: Sprite::new(Vec2::new(window.width / 2.0, wall_thickness)),
-            transform: Transform::from_xyz(-window.width / 4.0, (window.height / 2.0) - 1.0, 0.0),
-            ..Default::default()
-        })
-        .insert(WallSide::Left);
-    commands
+    commands // Left wall
         .spawn_bundle(SpriteBundle {
             material: wall_material.clone(),
             sprite: Sprite::new(Vec2::new(wall_thickness, window.height)),
             transform: Transform::from_xyz((-window.width / 2.0) + 1.0, 0.0, 0.0),
             ..Default::default()
         })
-        .insert(WallSide::Left);
-    commands
-        .spawn_bundle(SpriteBundle {
-            material: wall_material.clone(),
-            sprite: Sprite::new(Vec2::new(window.width / 2.0, wall_thickness)),
-            transform: Transform::from_xyz(-window.width / 4.0, -(window.height / 2.0) + 1.0, 0.0),
-            ..Default::default()
-        })
-        .insert(WallSide::Left);
-    // Right Side -> Top, Right, Bottom
-    commands
-        .spawn_bundle(SpriteBundle {
-            material: wall_material.clone(),
-            sprite: Sprite::new(Vec2::new(window.width / 2.0, wall_thickness)),
-            transform: Transform::from_xyz(window.width / 4.0, (window.height / 2.0) - 1.0, 0.0),
-            ..Default::default()
-        })
-        .insert(WallSide::Right);
-    commands
+        .insert(WallSide::Left)
+        .insert(Collidable::End);
+
+    commands // Right wall
         .spawn_bundle(SpriteBundle {
             material: wall_material.clone(),
             sprite: Sprite::new(Vec2::new(wall_thickness, window.height)),
             transform: Transform::from_xyz((window.width / 2.0) - 1.0, 0.0, 0.0),
             ..Default::default()
         })
-        .insert(WallSide::Right);
-    commands
+        .insert(WallSide::Right)
+        .insert(Collidable::End);
+
+    commands // Top wall
         .spawn_bundle(SpriteBundle {
-            material: wall_material,
-            sprite: Sprite::new(Vec2::new(window.width / 2.0, wall_thickness)),
-            transform: Transform::from_xyz(window.width / 4.0, -(window.height / 2.0) + 1.0, 0.0),
+            material: wall_material.clone(),
+            sprite: Sprite::new(Vec2::new(window.width, wall_thickness)),
+            transform: Transform::from_xyz(0.0, (window.height / 2.0) - 1.0, 0.0),
             ..Default::default()
         })
-        .insert(WallSide::Right);
+        .insert(Collidable::Reflect);
+    commands // Bottom wall
+        .spawn_bundle(SpriteBundle {
+            material: wall_material,
+            sprite: Sprite::new(Vec2::new(window.width, wall_thickness)),
+            transform: Transform::from_xyz(0.0, -(window.height / 2.0) + 1.0, 0.0),
+            ..Default::default()
+        })
+        .insert(Collidable::Reflect);
 
     // Dashes
     let window_top = (window.height / 2.0).abs();

--- a/src/systems/collision.rs
+++ b/src/systems/collision.rs
@@ -1,161 +1,39 @@
-use crate::{Ball, Player, PlayerType, Velocity, WallSide};
+use crate::{Ball, Collidable, Player, PlayerType, Velocity, WallSide};
 use bevy::{prelude::*, sprite};
 
 type Collision = sprite::collide_aabb::Collision;
 
-// TODO: Bevy provides a mechanism to create sub-systems. I imagine we would group together
-// multiple different collision systems together in order to compose everything.
+#[allow(clippy::type_complexity)]
 pub fn collision_system(
     mut commands: Commands,
     mut ball_query: Query<(Entity, &Transform, &Sprite, &mut Velocity, &Ball)>,
-    player_query: Query<(&Transform, &Sprite, &Player)>,
-    wall_query: Query<(&Transform, &Sprite, &WallSide)>,
+    collidables_query: Query<(&Collidable, Option<&WallSide>, &Transform, &Sprite)>,
 ) {
-    if let Ok((entity, ball_transform, ball_sprite, mut ball_velocity, _)) = ball_query.single_mut()
+    if let Ok((ball_entity, ball_transform, ball_sprite, mut ball_velocity, _)) =
+        ball_query.single_mut()
     {
-        for (wall_transform, wall_size, wall_side) in wall_query.iter() {
-            if let Some(side) = wall_collision(
-                ball_transform,
-                ball_sprite,
-                wall_transform,
-                wall_size,
-                wall_side,
-            ) {
-                // https://bevy-cheatbook.github.io/programming/commands.html
-                commands.entity(entity).insert(side);
-                break;
-            }
-        }
-
-        for (player_transform, player_size, player_type) in player_query.iter() {
-            paddle_collision(
-                ball_transform,
-                ball_sprite,
-                &mut ball_velocity,
-                player_transform,
-                player_size,
-                player_type,
-            );
-        }
-    }
-}
-
-fn wall_collision(
-    ball_transform: &Transform,
-    ball_sprite: &Sprite,
-    wall_transform: &Transform,
-    wall_sprite: &Sprite,
-    wall_side: &WallSide,
-) -> Option<WallSide> {
-    let ball_pos = ball_transform.translation;
-    let ball_size = ball_sprite.size; //Vec2::from((ball_size.width, ball_size.height));
-    let wall_pos = wall_transform.translation;
-    let wall_size = wall_sprite.size; // Vec2::from((wall_.size.x, wall_size.size.y));
-
-    // let collision = sprite::collide_aabb::collide(ball_pos, ball_size, wall_pos, wall_size);
-    match (
-        wall_side,
-        sprite::collide_aabb::collide(ball_pos, ball_size, wall_pos, wall_size),
-    ) {
-        (WallSide::Left, Some(_)) => Some(WallSide::Left),
-        (WallSide::Right, Some(_)) => Some(WallSide::Right),
-        (_, None) => None,
-    }
-}
-
-fn paddle_collision(
-    ball_transform: &Transform,
-    ball_sprite: &Sprite,
-    ball_velocity: &mut Velocity,
-    player_transform: &Transform,
-    player_sprite: &Sprite,
-    player_type: &Player,
-) {
-    let ball_pos = ball_transform.translation;
-    let ball_size = ball_sprite.size; // Vec2::from((ball_size.width, ball_size.height));
-    let player_pos = player_transform.translation;
-    let player_size = player_sprite.size; // Vec2::from((player_size.width, player_size.height));
-    if let Some(collision) =
-        sprite::collide_aabb::collide(ball_pos, ball_size, player_pos, player_size)
-    {
-        match (player_type, collision) {
-            // Right Player
-            (
-                Player {
-                    player_type: PlayerType::Right,
-                },
-                Collision::Left,
-            ) => {
-                println!("Ball collided with the right paddle on the left size");
-                ball_velocity.0.x *= -1.0;
-                ball_velocity.0.y *= -1.0;
-            }
-            (
-                Player {
-                    player_type: PlayerType::Right,
-                },
-                Collision::Top,
-            ) => {
-                println!("Ball collided with the right paddle on the top size");
-                ball_velocity.0.x *= -1.0;
-                ball_velocity.0.y *= -1.0;
-            }
-            (
-                Player {
-                    player_type: PlayerType::Right,
-                },
-                Collision::Bottom,
-            ) => {
-                println!("Ball collided with the right paddle on the bottom size");
-                ball_velocity.0.x *= -1.0;
-                ball_velocity.0.y *= -1.0;
-            }
-            (
-                Player {
-                    player_type: PlayerType::Right,
-                },
-                _,
-            ) => {
-                println!("Ball collided with the right paddle on top, right, or bottom");
-            }
-            // Left Player
-            (
-                Player {
-                    player_type: PlayerType::Left,
-                },
-                Collision::Right,
-            ) => {
-                println!("Ball collided with the left paddle on the right side");
-                ball_velocity.0.x *= -1.0;
-                ball_velocity.0.y *= -1.0;
-            }
-            (
-                Player {
-                    player_type: PlayerType::Left,
-                },
-                Collision::Top,
-            ) => {
-                println!("Ball collided with the left paddle on the top side");
-                ball_velocity.0.x *= -1.0;
-                ball_velocity.0.y *= -1.0;
-            }
-            (
-                Player {
-                    player_type: PlayerType::Left,
-                },
-                Collision::Bottom,
-            ) => {
-                println!("Ball collided with the left paddle on the bottom side");
-                ball_velocity.0.x *= -1.0;
-                ball_velocity.0.y *= -1.0;
-            }
-            (
-                Player {
-                    player_type: PlayerType::Left,
-                },
-                _,
-            ) => {
-                println!("Ball collided with the left paddle on the top, left, or bottom")
+        for (collide_type, wallside, collide_transform, collide_sprite) in collidables_query.iter()
+        {
+            let ball_pos = ball_transform.translation;
+            let ball_size = ball_sprite.size;
+            let collide_pos = collide_transform.translation;
+            let collide_size = collide_sprite.size;
+            if let Some(collision) =
+                sprite::collide_aabb::collide(ball_pos, ball_size, collide_pos, collide_size)
+            {
+                match (collide_type, collision, wallside) {
+                    (Collidable::Reflect, _, _) => {
+                        ball_velocity.0.x *= -1.0;
+                        ball_velocity.0.y *= -1.0;
+                    }
+                    (Collidable::End, _, Some(WallSide::Left)) => {
+                        commands.entity(ball_entity).insert(WallSide::Left);
+                    }
+                    (Collidable::End, _, Some(WallSide::Right)) => {
+                        commands.entity(ball_entity).insert(WallSide::Left);
+                    }
+                    (_, _, None) => (),
+                }
             }
         }
     }

--- a/src/systems/collision.rs
+++ b/src/systems/collision.rs
@@ -1,4 +1,4 @@
-use crate::{Ball, Player, PlayerType, Velocity};
+use crate::{Ball, Player, PlayerType, Velocity, Wall, WallSide};
 use bevy::{prelude::*, sprite};
 
 type Collision = sprite::collide_aabb::Collision;
@@ -6,97 +6,166 @@ type Collision = sprite::collide_aabb::Collision;
 pub fn collision_system(
     mut ball_query: Query<(&Transform, &Size, &mut Velocity, &Ball)>,
     player_query: Query<(&Transform, &Size, &Player)>,
+    wall_query: Query<(&Transform, &Size, &Wall)>,
 ) {
     if let Ok((ball_transform, ball_size, mut ball_velocity, _)) = ball_query.single_mut() {
-        // TODO: check if the next frame, instead of the current frame, is a collision
+        for (wall_transform, wall_size, wall) in wall_query.iter() {
+            if wall_collision(
+                &ball_transform,
+                &ball_size,
+                &ball_velocity,
+                &wall_transform,
+                &wall_size,
+                &wall,
+            ) {
+                break;
+            }
+        }
+
         for (player_transform, player_size, player_type) in player_query.iter() {
-            let ball_pos = ball_transform.translation;
-            let ball_size = Vec2::from((ball_size.width, ball_size.height));
-            let player_pos = player_transform.translation;
-            let player_size = Vec2::from((player_size.width, player_size.height));
-            if let Some(collision) =
-                sprite::collide_aabb::collide(ball_pos, ball_size, player_pos, player_size)
-            {
-                match (player_type, collision) {
-                    // Right Player
-                    (
-                        Player {
-                            player_type: PlayerType::RightPlayer,
-                        },
-                        Collision::Left,
-                    ) => {
-                        println!("Ball collided with the right paddle on the left size");
-                        ball_velocity.0.x *= -1.0;
-                        ball_velocity.0.y *= -1.0;
-                    }
-                    (
-                        Player {
-                            player_type: PlayerType::RightPlayer,
-                        },
-                        Collision::Top,
-                    ) => {
-                        println!("Ball collided with the right paddle on the top size");
-                        ball_velocity.0.x *= -1.0;
-                        ball_velocity.0.y *= -1.0;
-                    }
-                    (
-                        Player {
-                            player_type: PlayerType::RightPlayer,
-                        },
-                        Collision::Bottom,
-                    ) => {
-                        println!("Ball collided with the right paddle on the bottom size");
-                        ball_velocity.0.x *= -1.0;
-                        ball_velocity.0.y *= -1.0;
-                    }
-                    (
-                        Player {
-                            player_type: PlayerType::RightPlayer,
-                        },
-                        _,
-                    ) => {
-                        println!("Ball collided with the right paddle on top, right, or bottom");
-                    }
-                    // Left Player
-                    (
-                        Player {
-                            player_type: PlayerType::LeftPlayer,
-                        },
-                        Collision::Right,
-                    ) => {
-                        println!("Ball collided with the left paddle on the right side");
-                        ball_velocity.0.x *= -1.0;
-                        ball_velocity.0.y *= -1.0;
-                    }
-                    (
-                        Player {
-                            player_type: PlayerType::LeftPlayer,
-                        },
-                        Collision::Top,
-                    ) => {
-                        println!("Ball collided with the left paddle on the top side");
-                        ball_velocity.0.x *= -1.0;
-                        ball_velocity.0.y *= -1.0;
-                    }
-                    (
-                        Player {
-                            player_type: PlayerType::LeftPlayer,
-                        },
-                        Collision::Bottom,
-                    ) => {
-                        println!("Ball collided with the left paddle on the bottom side");
-                        ball_velocity.0.x *= -1.0;
-                        ball_velocity.0.y *= -1.0;
-                    }
-                    (
-                        Player {
-                            player_type: PlayerType::LeftPlayer,
-                        },
-                        _,
-                    ) => {
-                        println!("Ball collided with the left paddle on the top, left, or bottom")
-                    }
-                }
+            paddle_collision(
+                &ball_transform,
+                &ball_size,
+                &mut ball_velocity,
+                &player_transform,
+                &player_size,
+                &player_type,
+            );
+        }
+    }
+}
+
+fn wall_collision(
+    ball_transform: &Transform,
+    ball_size: &Size,
+    ball_velocity: &Velocity,
+    wall_transform: &Transform,
+    wall_size: &Size,
+    wall: &Wall,
+) -> bool {
+    let ball_pos = ball_transform.translation;
+    let ball_size = Vec2::from((ball_size.width, ball_size.height));
+    let wall_pos = wall_transform.translation;
+    let wall_size = Vec2::from((wall_size.width, wall_size.height));
+
+    // TODO: Need to add Entity to the query, then need to insert a component that says that there
+    // has been a game ending collision
+    //
+    // https://bevy-cheatbook.github.io/programming/commands.html
+    if let Some(collision) = sprite::collide_aabb::collide(ball_pos, ball_size, wall_pos, wall_size)
+    {
+        match (wall, collision) {
+            (
+                Wall {
+                    side: WallSide::Left,
+                },
+                _,
+            ) => true,
+            (
+                Wall {
+                    side: WallSide::Right,
+                },
+                _,
+            ) => true,
+        }
+    } else {
+        false
+    }
+}
+
+fn paddle_collision(
+    ball_transform: &Transform,
+    ball_size: &Size,
+    ball_velocity: &mut Velocity,
+    player_transform: &Transform,
+    player_size: &Size,
+    player_type: &Player,
+) {
+    let ball_pos = ball_transform.translation;
+    let ball_size = Vec2::from((ball_size.width, ball_size.height));
+    let player_pos = player_transform.translation;
+    let player_size = Vec2::from((player_size.width, player_size.height));
+    if let Some(collision) =
+        sprite::collide_aabb::collide(ball_pos, ball_size, player_pos, player_size)
+    {
+        match (player_type, collision) {
+            // Right Player
+            (
+                Player {
+                    player_type: PlayerType::RightPlayer,
+                },
+                Collision::Left,
+            ) => {
+                println!("Ball collided with the right paddle on the left size");
+                ball_velocity.0.x *= -1.0;
+                ball_velocity.0.y *= -1.0;
+            }
+            (
+                Player {
+                    player_type: PlayerType::RightPlayer,
+                },
+                Collision::Top,
+            ) => {
+                println!("Ball collided with the right paddle on the top size");
+                ball_velocity.0.x *= -1.0;
+                ball_velocity.0.y *= -1.0;
+            }
+            (
+                Player {
+                    player_type: PlayerType::RightPlayer,
+                },
+                Collision::Bottom,
+            ) => {
+                println!("Ball collided with the right paddle on the bottom size");
+                ball_velocity.0.x *= -1.0;
+                ball_velocity.0.y *= -1.0;
+            }
+            (
+                Player {
+                    player_type: PlayerType::RightPlayer,
+                },
+                _,
+            ) => {
+                println!("Ball collided with the right paddle on top, right, or bottom");
+            }
+            // Left Player
+            (
+                Player {
+                    player_type: PlayerType::LeftPlayer,
+                },
+                Collision::Right,
+            ) => {
+                println!("Ball collided with the left paddle on the right side");
+                ball_velocity.0.x *= -1.0;
+                ball_velocity.0.y *= -1.0;
+            }
+            (
+                Player {
+                    player_type: PlayerType::LeftPlayer,
+                },
+                Collision::Top,
+            ) => {
+                println!("Ball collided with the left paddle on the top side");
+                ball_velocity.0.x *= -1.0;
+                ball_velocity.0.y *= -1.0;
+            }
+            (
+                Player {
+                    player_type: PlayerType::LeftPlayer,
+                },
+                Collision::Bottom,
+            ) => {
+                println!("Ball collided with the left paddle on the bottom side");
+                ball_velocity.0.x *= -1.0;
+                ball_velocity.0.y *= -1.0;
+            }
+            (
+                Player {
+                    player_type: PlayerType::LeftPlayer,
+                },
+                _,
+            ) => {
+                println!("Ball collided with the left paddle on the top, left, or bottom")
             }
         }
     }

--- a/src/systems/collision.rs
+++ b/src/systems/collision.rs
@@ -1,4 +1,4 @@
-use crate::{Ball, Collidable, Player, PlayerType, Velocity, WallSide};
+use crate::{Ball, Collidable, Velocity, WallSide};
 use bevy::{prelude::*, sprite};
 
 type Collision = sprite::collide_aabb::Collision;

--- a/src/systems/collision.rs
+++ b/src/systems/collision.rs
@@ -23,12 +23,9 @@ pub fn collision_system(
             ) {
                 // https://bevy-cheatbook.github.io/programming/commands.html
                 commands.entity(entity).insert(side);
-                println!("JRY INSERTED COLLISION SIDE TO BALL");
                 break;
             }
         }
-
-        println!("JRY BALL POS = {:?}", ball_transform.translation);
 
         for (player_transform, player_size, player_type) in player_query.iter() {
             paddle_collision(
@@ -60,22 +57,8 @@ fn wall_collision(
         wall_side,
         sprite::collide_aabb::collide(ball_pos, ball_size, wall_pos, wall_size),
     ) {
-        (WallSide::Left, Some(_)) => {
-            // println!(
-            //     "JRY --------- ball_pos = {:?} wall_pos = {:?} wall_size = {:?}",
-            //     ball_pos, wall_pos, wall_size
-            // );
-            // println!("JRY --------- collision ={:?}", collision);
-            Some(WallSide::Left)
-        }
-        (WallSide::Right, Some(_)) => {
-            // println!(
-            //     "JRY --------- ball_pos = {:?} wall_pos = {:?} wall_size = {:?}",
-            //     ball_pos, wall_pos, wall_size
-            // );
-            // println!("JRY --------- collision ={:?}", collision);
-            Some(WallSide::Right)
-        }
+        (WallSide::Left, Some(_)) => Some(WallSide::Left),
+        (WallSide::Right, Some(_)) => Some(WallSide::Right),
         (_, None) => None,
     }
 }

--- a/src/systems/input.rs
+++ b/src/systems/input.rs
@@ -1,4 +1,5 @@
-use crate::{Player, PlayerType, Position};
+use crate::constants::{PADDLE_HEIGHT, PADDLE_VELOCITY};
+use crate::{Player, PlayerType};
 use bevy::prelude::*;
 
 // Controls
@@ -8,25 +9,31 @@ use bevy::prelude::*;
 // Player 2 -> UP -> 'W' Key
 // Player 2 -> DOWN -> 'S' Key
 pub fn keyboard_input_system(
-    mut players: Query<(&mut Position, &Player)>,
+    mut players: Query<(&mut Transform, &Player)>,
     key: Res<Input<KeyCode>>,
+    window: Res<WindowDescriptor>,
 ) {
-    for (mut position, player) in players.iter_mut() {
+    for (mut transform, player) in players.iter_mut() {
         match player.player_type {
             PlayerType::Left => {
                 if key.pressed(KeyCode::W) {
-                    position.y += 1.0
+                    transform.translation.y += PADDLE_VELOCITY
                 } else if key.pressed(KeyCode::S) {
-                    position.y -= 1.0
+                    transform.translation.y -= PADDLE_VELOCITY
                 }
             }
             PlayerType::Right => {
                 if key.pressed(KeyCode::Up) {
-                    position.y += 1.0
+                    transform.translation.y += PADDLE_VELOCITY
                 } else if key.pressed(KeyCode::Down) {
-                    position.y -= 1.0
+                    transform.translation.y -= PADDLE_VELOCITY
                 }
             }
         }
+        transform.translation.y = transform
+            .translation
+            .y
+            .max(-(window.height / 2.0) + PADDLE_HEIGHT / 2.0)
+            .min((window.height / 2.0) - PADDLE_HEIGHT / 2.0);
     }
 }

--- a/src/systems/input.rs
+++ b/src/systems/input.rs
@@ -1,0 +1,32 @@
+use crate::{Player, PlayerType, Position};
+use bevy::prelude::*;
+
+// Controls
+// ----------------------------------
+// Player 1 -> UP -> Up Arrow Key
+// Player 1 -> DOWN -> Down Arrow Key
+// Player 2 -> UP -> 'W' Key
+// Player 2 -> DOWN -> 'S' Key
+pub fn keyboard_input_system(
+    mut players: Query<(&mut Position, &Player)>,
+    key: Res<Input<KeyCode>>,
+) {
+    for (mut position, player) in players.iter_mut() {
+        match player.player_type {
+            PlayerType::Left => {
+                if key.pressed(KeyCode::W) {
+                    position.y += 1.0
+                } else if key.pressed(KeyCode::S) {
+                    position.y -= 1.0
+                }
+            }
+            PlayerType::Right => {
+                if key.pressed(KeyCode::Up) {
+                    position.y += 1.0
+                } else if key.pressed(KeyCode::Down) {
+                    position.y -= 1.0
+                }
+            }
+        }
+    }
+}

--- a/src/systems/mod.rs
+++ b/src/systems/mod.rs
@@ -1,3 +1,4 @@
 pub mod collision;
+pub mod input;
 pub mod round;
 pub mod velocity;

--- a/src/systems/mod.rs
+++ b/src/systems/mod.rs
@@ -1,2 +1,3 @@
 pub mod collision;
+pub mod round;
 pub mod velocity;

--- a/src/systems/round.rs
+++ b/src/systems/round.rs
@@ -12,7 +12,7 @@ pub fn round_system(
     mut commands: Commands,
     mut game: ResMut<Game>,
     mut ball_query: Query<(Entity, &WallSide), With<Ball>>,
-    mut player_query: Query<(Entity, &Player), With<Player>>,
+    player_query: Query<(Entity, &Player), With<Player>>,
 ) {
     if let Ok((ball_entity, wall_side_collision)) = ball_query.single_mut() {
         // Increment score

--- a/src/systems/round.rs
+++ b/src/systems/round.rs
@@ -31,7 +31,7 @@ pub fn round_system(
         commands.entity(ball_entity).remove::<Position>();
         commands.entity(ball_entity).remove::<Transform>();
         commands.entity(ball_entity).remove::<Velocity>();
-        println!("REMOVED BALL WALLSIDE, POSITION, TRANSFORM");
+        // Insert initial state
         commands.entity(ball_entity).insert(BALL_ORIGIN);
         commands.entity(ball_entity).insert(Transform::from_xyz(
             BALL_ORIGIN.x / 100.0 * window.width,
@@ -41,13 +41,13 @@ pub fn round_system(
 
         // Reset position for paddles
         for (player_entity, player) in player_query.iter() {
-            println!("REMOVED PLAYER POSITION, TRANSFORM");
             commands.entity(player_entity).remove::<Position>();
             commands.entity(player_entity).remove::<Transform>();
             let origin = match player.player_type {
                 PlayerType::Left => LEFT_PLAYER_ORIGIN,
                 PlayerType::Right => RIGHT_PLAYER_ORIGIN,
             };
+            // Insert initial state
             commands.entity(player_entity).insert(origin.clone());
             commands.entity(player_entity).insert(Transform::from_xyz(
                 origin.x / 100.0 * window.width,

--- a/src/systems/round.rs
+++ b/src/systems/round.rs
@@ -1,0 +1,5 @@
+// TODO
+// 1. Respond when ball collides on left half or right half
+// 2. Assign a point to a player
+// 3. Restart the round (somehow, probably by calling similar code to the startup system)
+pub fn round_system() {}

--- a/src/systems/round.rs
+++ b/src/systems/round.rs
@@ -1,5 +1,59 @@
-// TODO
+use crate::{
+    Ball, Game, Player, PlayerType, Position, PrevWinner, Velocity, WallSide, BALL_ORIGIN,
+    LEFT_PLAYER_ORIGIN, RIGHT_PLAYER_ORIGIN,
+};
+use bevy::prelude::*;
+
 // 1. Respond when ball collides on left half or right half
 // 2. Assign a point to a player
 // 3. Restart the round (somehow, probably by calling similar code to the startup system)
-pub fn round_system() {}
+pub fn round_system(
+    window: Res<WindowDescriptor>,
+    mut commands: Commands,
+    mut game: ResMut<Game>,
+    mut ball_query: Query<(Entity, &WallSide), With<Ball>>,
+    mut player_query: Query<(Entity, &Player), With<Player>>,
+) {
+    if let Ok((ball_entity, wall_side_collision)) = ball_query.single_mut() {
+        // Increment score
+        match wall_side_collision {
+            WallSide::Left => {
+                game.right_score += 1;
+                game.prev_winner = PrevWinner::Player(PlayerType::Right);
+            }
+            WallSide::Right => {
+                game.left_score += 1;
+                game.prev_winner = PrevWinner::Player(PlayerType::Left);
+            }
+        }
+        // Remove collision side from ball
+        commands.entity(ball_entity).remove::<WallSide>();
+        commands.entity(ball_entity).remove::<Position>();
+        commands.entity(ball_entity).remove::<Transform>();
+        commands.entity(ball_entity).remove::<Velocity>();
+        println!("REMOVED BALL WALLSIDE, POSITION, TRANSFORM");
+        commands.entity(ball_entity).insert(BALL_ORIGIN);
+        commands.entity(ball_entity).insert(Transform::from_xyz(
+            BALL_ORIGIN.x / 100.0 * window.width,
+            BALL_ORIGIN.y / 100.0 * window.height,
+            0.0,
+        ));
+
+        // Reset position for paddles
+        for (player_entity, player) in player_query.iter() {
+            println!("REMOVED PLAYER POSITION, TRANSFORM");
+            commands.entity(player_entity).remove::<Position>();
+            commands.entity(player_entity).remove::<Transform>();
+            let origin = match player.player_type {
+                PlayerType::Left => LEFT_PLAYER_ORIGIN,
+                PlayerType::Right => RIGHT_PLAYER_ORIGIN,
+            };
+            commands.entity(player_entity).insert(origin.clone());
+            commands.entity(player_entity).insert(Transform::from_xyz(
+                origin.x / 100.0 * window.width,
+                origin.y / 100.0 * window.height,
+                0.0,
+            ));
+        }
+    }
+}

--- a/src/systems/round.rs
+++ b/src/systems/round.rs
@@ -1,7 +1,4 @@
-use crate::{
-    Ball, Game, Player, PlayerType, Position, PrevWinner, Velocity, WallSide, BALL_ORIGIN,
-    LEFT_PLAYER_ORIGIN, RIGHT_PLAYER_ORIGIN,
-};
+use crate::{Ball, Game, Player, PlayerType, PrevWinner, Velocity, WallSide};
 use bevy::prelude::*;
 
 // 1. Respond when ball collides on left half or right half
@@ -28,32 +25,23 @@ pub fn round_system(
         }
         // Remove collision side from ball
         commands.entity(ball_entity).remove::<WallSide>();
-        commands.entity(ball_entity).remove::<Position>();
         commands.entity(ball_entity).remove::<Transform>();
         commands.entity(ball_entity).remove::<Velocity>();
         // Insert initial state
-        commands.entity(ball_entity).insert(BALL_ORIGIN);
-        commands.entity(ball_entity).insert(Transform::from_xyz(
-            BALL_ORIGIN.x / 100.0 * window.width,
-            BALL_ORIGIN.y / 100.0 * window.height,
-            0.0,
-        ));
+        commands
+            .entity(ball_entity)
+            .insert(Transform::from_xyz(0.0, 0.0, 0.0));
 
         // Reset position for paddles
         for (player_entity, player) in player_query.iter() {
-            commands.entity(player_entity).remove::<Position>();
             commands.entity(player_entity).remove::<Transform>();
-            let origin = match player.player_type {
-                PlayerType::Left => LEFT_PLAYER_ORIGIN,
-                PlayerType::Right => RIGHT_PLAYER_ORIGIN,
-            };
             // Insert initial state
-            commands.entity(player_entity).insert(origin.clone());
-            commands.entity(player_entity).insert(Transform::from_xyz(
-                origin.x / 100.0 * window.width,
-                origin.y / 100.0 * window.height,
-                0.0,
-            ));
+            commands
+                .entity(player_entity)
+                .insert(match player.player_type {
+                    PlayerType::Left => Transform::from_xyz(-0.425 * window.width, 0.0, 0.0),
+                    PlayerType::Right => Transform::from_xyz(0.425 * window.width, 0.0, 0.0),
+                });
         }
     }
 }

--- a/src/systems/velocity.rs
+++ b/src/systems/velocity.rs
@@ -1,9 +1,9 @@
-use crate::{Position, Velocity};
+use crate::Velocity;
 use bevy::prelude::*;
 
-pub fn velocity_system(mut query: Query<(&mut Position, &Velocity)>) {
-    for (mut position, velocity) in query.iter_mut() {
-        position.x += velocity.0.x;
-        position.y += velocity.0.y;
+pub fn velocity_system(mut query: Query<(&mut Transform, &Velocity)>) {
+    for (mut transform, velocity) in query.iter_mut() {
+        transform.translation.x += velocity.0.x;
+        transform.translation.y += velocity.0.y;
     }
 }


### PR DESCRIPTION
1. Adds a global Resource called `Game` which keeps track of the left and right player score, as well as who the previous winner was. We should use the previous winner to determine who the loser was in order to shoot the ball towards them

2. Adds entities that represent the walls, with `WallSide` components which are enums
 
3. Adds separates the collision system in to `paddle_collision` and `wall_collision`. 
`wall_collision` will attach a component to the ball entity that describes which wall the ball collided into. The `round_system` will pickup the ball's `WallSide` and use it to assign scores, define the `PrevWinner`, as well as reset the paddles and ball to the original starting position. (See refactor opportunity below)

4. Adds `round_system` which handles game score, game state, and resetting the game. Anther system might update the text on the screen based on what the `round_system` does.


---

### ~TODO~ DONE

1. I made the top and bottom walls end the game, that basically makes pong unplayable, I'll fix this shortly by refactoring how collisions work (see below)

### Refactor Opportunity

It occurred to me that the most ECS way to do this is actually to define a `Collidable` (enum) component and attach it to the different entities.

For example `Player` is a `Collidable::Reflect` meaning that the collision system will just look for all entities that have `Reflect` and do the ball reflection

However the leftmost and rightmost walls are `Collidable::End` where we want to check for a collision but not reflect, this is where we can check the wall sides, and attach which wall collided with the ball on to the ball entity[