### PR TITLE
Prevent paddles from going off the screen

### DIFF
--- a/src/constants.rs
+++ b/src/constants.rs
@@ -1,8 +1,3 @@
-use crate::Position;
-
-pub const LEFT_PLAYER_ORIGIN: Position = Position { x: -42.5, y: 0.0 };
-pub const RIGHT_PLAYER_ORIGIN: Position = Position { x: 42.5, y: 0.0 };
-pub const BALL_ORIGIN: Position = Position { x: 0.0, y: 0.0 };
 pub const BALL_SIZE: [f32; 2] = [5.0, 5.0];
 pub const PADDLE_HEIGHT: f32 = 36.0;
 pub const PADDLE_SIZE: [f32; 2] = [6.0, PADDLE_HEIGHT];
@@ -10,3 +5,4 @@ pub const DASH_WIDTH: f32 = 1.0;
 pub const DASH_HEIGHT: f32 = 8.0;
 pub const DASH_SIZE: [f32; 2] = [DASH_WIDTH, DASH_HEIGHT];
 pub const DASH_PADDING: f32 = 20.0;
+pub const PADDLE_VELOCITY: f32 = 10.0;

--- a/src/main.rs
+++ b/src/main.rs
@@ -37,13 +37,6 @@ pub struct Player {
     player_type: PlayerType,
 }
 
-// Positions are percentage based
-#[derive(Clone)]
-pub struct Position {
-    x: f32,
-    y: f32,
-}
-
 pub struct Velocity(Vec2);
 pub struct Ball;
 pub struct LostRound;
@@ -85,7 +78,7 @@ fn main() {
                 .with_system(collision_system.system().label("collision"))
                 .with_system(velocity_system.system().after("collision")),
         )
-        .add_system(render_system.system().after("physics"))
+        // .add_system(render_system.system().after("physics"))
         .run();
 }
 
@@ -104,13 +97,13 @@ fn startup_system(
         .spawn_bundle(SpriteBundle {
             material: materials.add(Color::rgb(1.0, 1.0, 1.0).into()),
             sprite: Sprite::new(Vec2::from(PADDLE_SIZE)),
+            transform: Transform::from_xyz(0.425 * -window.width, 0.0, 0.0),
             ..Default::default()
         })
         .insert(Player {
             player_type: PlayerType::Left,
         })
         .insert(Size::new(PADDLE_SIZE[0], PADDLE_SIZE[1]))
-        .insert(LEFT_PLAYER_ORIGIN)
         .insert(Collidable::Reflect);
 
     // Right Player
@@ -118,13 +111,13 @@ fn startup_system(
         .spawn_bundle(SpriteBundle {
             material: materials.add(Color::rgb(1.0, 1.0, 1.0).into()),
             sprite: Sprite::new(Vec2::from(PADDLE_SIZE)),
+            transform: Transform::from_xyz(0.425 * window.width, 0.0, 0.0),
             ..Default::default()
         })
         .insert(Player {
             player_type: PlayerType::Right,
         })
         .insert(Size::new(PADDLE_SIZE[0], PADDLE_SIZE[1]))
-        .insert(RIGHT_PLAYER_ORIGIN)
         .insert(Collidable::Reflect);
 
     // Ball
@@ -132,12 +125,12 @@ fn startup_system(
         .spawn_bundle(SpriteBundle {
             material: materials.add(Color::rgb(1.0, 1.0, 1.0).into()),
             sprite: Sprite::new(Vec2::from(BALL_SIZE)),
+            transform: Transform::from_xyz(0.0, 0.0, 0.0),
             ..Default::default()
         })
         .insert(Ball)
-        .insert(BALL_ORIGIN)
         .insert(Size::new(BALL_SIZE[0], BALL_SIZE[1]))
-        .insert(Velocity(Vec2::new(0.65, 0.0)));
+        .insert(Velocity(Vec2::new(5.0, 0.0)));
 
     // Invisible walls for collision detection
     let wall_material = materials.add(Color::rgb(1.0, 1.0, 1.0).into());
@@ -198,11 +191,11 @@ fn startup_system(
     commands.spawn_batch(dashes);
 }
 
-// Convert relative position to absolute
-fn render_system(mut query: Query<(&Position, &mut Transform)>, window: Res<WindowDescriptor>) {
-    for (position, mut transform) in query.iter_mut() {
-        let translation = &mut transform.translation;
-        translation.x = position.x / 100.0 * window.width;
-        translation.y = position.y / 100.0 * window.height;
-    }
-}
+// // Convert relative position to absolute
+// fn render_system(mut query: Query<(&Position, &mut Transform)>, window: Res<WindowDescriptor>) {
+//     for (position, mut transform) in query.iter_mut() {
+//         let translation = &mut transform.translation;
+//         translation.x = position.x / 100.0 * window.width;
+//         translation.y = position.y / 100.0 * window.height;
+//     }
+// }

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,7 +2,10 @@ mod constants;
 mod systems;
 
 use crate::constants::*;
-use crate::systems::{collision::collision_system, round::round_system, velocity::velocity_system};
+use crate::systems::{
+    collision::collision_system, input::keyboard_input_system, round::round_system,
+    velocity::velocity_system,
+};
 use bevy::{prelude::*, render::pass::ClearColor};
 
 pub enum PrevWinner {
@@ -193,34 +196,6 @@ fn startup_system(
     }
 
     commands.spawn_batch(dashes);
-}
-
-// Controls
-// ----------------------------------
-// Player 1 -> UP -> Up Arrow Key
-// Player 1 -> DOWN -> Down Arrow Key
-// Player 2 -> UP -> 'W' Key
-// Player 2 -> DOWN -> 'S' Key
-#[allow(clippy::type_complexity)]
-fn keyboard_input_system(mut players: Query<(&mut Position, &Player)>, key: Res<Input<KeyCode>>) {
-    for (mut position, player) in players.iter_mut() {
-        match player.player_type {
-            PlayerType::Left => {
-                if key.pressed(KeyCode::W) {
-                    position.y += 1.0
-                } else if key.pressed(KeyCode::S) {
-                    position.y -= 1.0
-                }
-            }
-            PlayerType::Right => {
-                if key.pressed(KeyCode::Up) {
-                    position.y += 1.0
-                } else if key.pressed(KeyCode::Down) {
-                    position.y -= 1.0
-                }
-            }
-        }
-    }
 }
 
 // Convert relative position to absolute

--- a/src/systems/input.rs
+++ b/src/systems/input.rs
@@ -1,4 +1,5 @@
-use crate::{Player, PlayerType, Position};
+use crate::constants::{PADDLE_HEIGHT, PADDLE_VELOCITY};
+use crate::{Player, PlayerType};
 use bevy::prelude::*;
 
 // Controls
@@ -8,25 +9,31 @@ use bevy::prelude::*;
 // Player 2 -> UP -> 'W' Key
 // Player 2 -> DOWN -> 'S' Key
 pub fn keyboard_input_system(
-    mut players: Query<(&mut Position, &Player)>,
+    mut players: Query<(&mut Transform, &Player)>,
     key: Res<Input<KeyCode>>,
+    window: Res<WindowDescriptor>,
 ) {
-    for (mut position, player) in players.iter_mut() {
+    for (mut transform, player) in players.iter_mut() {
         match player.player_type {
             PlayerType::Left => {
                 if key.pressed(KeyCode::W) {
-                    position.y += 1.0
+                    transform.translation.y += PADDLE_VELOCITY
                 } else if key.pressed(KeyCode::S) {
-                    position.y -= 1.0
+                    transform.translation.y -= PADDLE_VELOCITY
                 }
             }
             PlayerType::Right => {
                 if key.pressed(KeyCode::Up) {
-                    position.y += 1.0
+                    transform.translation.y += PADDLE_VELOCITY
                 } else if key.pressed(KeyCode::Down) {
-                    position.y -= 1.0
+                    transform.translation.y -= PADDLE_VELOCITY
                 }
             }
         }
+        transform.translation.y = transform
+            .translation
+            .y
+            .max(-(window.height / 2.0) + PADDLE_HEIGHT / 2.0)
+            .min((window.height / 2.0) - PADDLE_HEIGHT / 2.0);
     }
 }

--- a/src/systems/input.rs
+++ b/src/systems/input.rs
@@ -1,0 +1,32 @@
+use crate::{Player, PlayerType, Position};
+use bevy::prelude::*;
+
+// Controls
+// ----------------------------------
+// Player 1 -> UP -> Up Arrow Key
+// Player 1 -> DOWN -> Down Arrow Key
+// Player 2 -> UP -> 'W' Key
+// Player 2 -> DOWN -> 'S' Key
+pub fn keyboard_input_system(
+    mut players: Query<(&mut Position, &Player)>,
+    key: Res<Input<KeyCode>>,
+) {
+    for (mut position, player) in players.iter_mut() {
+        match player.player_type {
+            PlayerType::Left => {
+                if key.pressed(KeyCode::W) {
+                    position.y += 1.0
+                } else if key.pressed(KeyCode::S) {
+                    position.y -= 1.0
+                }
+            }
+            PlayerType::Right => {
+                if key.pressed(KeyCode::Up) {
+                    position.y += 1.0
+                } else if key.pressed(KeyCode::Down) {
+                    position.y -= 1.0
+                }
+            }
+        }
+    }
+}

--- a/src/systems/mod.rs
+++ b/src/systems/mod.rs
@@ -1,3 +1,4 @@
 pub mod collision;
+pub mod input;
 pub mod round;
 pub mod velocity;

--- a/src/systems/round.rs
+++ b/src/systems/round.rs
@@ -1,7 +1,4 @@
-use crate::{
-    Ball, Game, Player, PlayerType, Position, PrevWinner, Velocity, WallSide, BALL_ORIGIN,
-    LEFT_PLAYER_ORIGIN, RIGHT_PLAYER_ORIGIN,
-};
+use crate::{Ball, Game, Player, PlayerType, PrevWinner, Velocity, WallSide};
 use bevy::prelude::*;
 
 // 1. Respond when ball collides on left half or right half
@@ -28,32 +25,23 @@ pub fn round_system(
         }
         // Remove collision side from ball
         commands.entity(ball_entity).remove::<WallSide>();
-        commands.entity(ball_entity).remove::<Position>();
         commands.entity(ball_entity).remove::<Transform>();
         commands.entity(ball_entity).remove::<Velocity>();
         // Insert initial state
-        commands.entity(ball_entity).insert(BALL_ORIGIN);
-        commands.entity(ball_entity).insert(Transform::from_xyz(
-            BALL_ORIGIN.x / 100.0 * window.width,
-            BALL_ORIGIN.y / 100.0 * window.height,
-            0.0,
-        ));
+        commands
+            .entity(ball_entity)
+            .insert(Transform::from_xyz(0.0, 0.0, 0.0));
 
         // Reset position for paddles
         for (player_entity, player) in player_query.iter() {
-            commands.entity(player_entity).remove::<Position>();
             commands.entity(player_entity).remove::<Transform>();
-            let origin = match player.player_type {
-                PlayerType::Left => LEFT_PLAYER_ORIGIN,
-                PlayerType::Right => RIGHT_PLAYER_ORIGIN,
-            };
             // Insert initial state
-            commands.entity(player_entity).insert(origin.clone());
-            commands.entity(player_entity).insert(Transform::from_xyz(
-                origin.x / 100.0 * window.width,
-                origin.y / 100.0 * window.height,
-                0.0,
-            ));
+            commands
+                .entity(player_entity)
+                .insert(match player.player_type {
+                    PlayerType::Left => Transform::from_xyz(-0.425 * window.width, 0.0, 0.0),
+                    PlayerType::Right => Transform::from_xyz(0.425 * window.width, 0.0, 0.0),
+                });
         }
     }
 }

--- a/src/systems/velocity.rs
+++ b/src/systems/velocity.rs
@@ -1,9 +1,9 @@
-use crate::{Position, Velocity};
+use crate::Velocity;
 use bevy::prelude::*;
 
-pub fn velocity_system(mut query: Query<(&mut Position, &Velocity)>) {
-    for (mut position, velocity) in query.iter_mut() {
-        position.x += velocity.0.x;
-        position.y += velocity.0.y;
+pub fn velocity_system(mut query: Query<(&mut Transform, &Velocity)>) {
+    for (mut transform, velocity) in query.iter_mut() {
+        transform.translation.x += velocity.0.x;
+        transform.translation.y += velocity.0.y;
     }
 }


### PR DESCRIPTION
@jeremyadamsfisher I finally got around to making this change, let me know what you think as it goes back on our initial decision to use relative coordinates.

To recap, the issue is that we were placing the paddles and ball using relative coordinates. When running the keyboard system, we need the real pixel coordinates in order to compute the size of the paddle to prevent it from going outside the bounds of the window.

Remove the `Position` struct and instead convert queries to use `Tranform` to get position related information from Bevy. When we do need relative positioning, compute the location using a scalar the `WindowDescriptor`, like so:

```rust
0.425 * window.width
```

The idea is to merge this PR into #5 for simplicity.